### PR TITLE
Fix sysroot generation target fail

### DIFF
--- a/Xilinx_Official_Platforms/xilinx_vck190_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_vck190_base/Makefile
@@ -43,7 +43,7 @@ linux: xsa
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
-	$(MAKE) -C sw/petalinux sysroot
+	$(MAKE) -C sw/build sysroot
 	@if [ -d $(SYSROOT) ]; then cp -rf $(SYSROOT) $(OUTPUT_PATH)/; fi
 
 .PHONY: platform

--- a/Xilinx_Official_Platforms/xilinx_zc706_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zc706_base/Makefile
@@ -43,7 +43,7 @@ linux: xsa
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
-	$(MAKE) -C sw/petalinux sysroot
+	$(MAKE) -C sw/build sysroot
 	@if [ -d $(SYSROOT) ]; then cp -rf $(SYSROOT) $(OUTPUT_PATH)/; fi
 
 .PHONY: platform

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base/Makefile
@@ -43,7 +43,7 @@ linux: xsa
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
-	$(MAKE) -C sw/petalinux sysroot
+	$(MAKE) -C sw/build sysroot
 	@if [ -d $(SYSROOT) ]; then cp -rf $(SYSROOT) $(OUTPUT_PATH)/; fi
 
 .PHONY: platform

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base/sw/petalinux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base/sw/petalinux/Makefile
@@ -38,12 +38,6 @@ image_rootfs:
 	cp -f images/linux/rootfs.tar.gz ${SW_COMP_DIR}/platform/filesystem/rootfs.tar.gz
 	cp -f images/linux/rootfs.ext4 ${SW_COMP_DIR}/platform/filesystem/rootfs.ext4
 
-xrt:
-	  petalinux-config -c xrt --silentconfig
-
-zocl:
-	  petalinux-config -c zocl --silentconfig
-
 all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs bootimage
 
 bootimage:

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/Makefile
@@ -43,7 +43,7 @@ linux: xsa
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
-	$(MAKE) -C sw/petalinux sysroot
+	$(MAKE) -C sw/build sysroot
 	@if [ -d $(SYSROOT) ]; then cp -rf $(SYSROOT) $(OUTPUT_PATH)/; fi
 
 .PHONY: platform

--- a/Xilinx_Official_Platforms/xilinx_zcu104_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu104_base/Makefile
@@ -43,7 +43,7 @@ linux: xsa
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
-	$(MAKE) -C sw/petalinux sysroot
+	$(MAKE) -C sw/build sysroot
 	@if [ -d $(SYSROOT) ]; then cp -rf $(SYSROOT) $(OUTPUT_PATH)/; fi
 
 .PHONY: platform


### PR DESCRIPTION
> used correct path for sysroot building in petalinux flow
> removed duplicate xrt and zocl targets in zcu102 makefile