### PR TITLE
Always generate BOOT.BIN only from post-impl PDI, Don't generate it by default

### DIFF
--- a/Xilinx_Official_Platforms/xilinx_vck190_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_vck190_base/Makefile
@@ -39,7 +39,7 @@ help::
 xsa:
 	$(MAKE) -C hw all
 
-linux: xsa
+linux: $(XSA)
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
@@ -52,7 +52,7 @@ platform:
 	@if [ -d $(SW_COMP_DIR)/platform/filesystem ]; then cp -rf ${SW_COMP_DIR}/platform/filesystem $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/sw/${PLATFORM_NAME}/xrt/; fi
 
 pre-built:
-	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
+	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir -p $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
 
 clean:
 	$(MAKE) -C hw clean

--- a/Xilinx_Official_Platforms/xilinx_vck190_base/sw/petalinux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_vck190_base/sw/petalinux/Makefile
@@ -35,14 +35,14 @@ image_rootfs:
 	cp -f images/linux/rootfs.tar.gz ${SW_COMP_DIR}/platform/filesystem/rootfs.tar.gz
 	cp -f images/linux/rootfs.ext4 ${SW_COMP_DIR}/platform/filesystem/rootfs.ext4
 
-all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs bootimage
+all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs
 
 bootimage:
 	$(info "BOOT image for platforms")
-	@if [ -f project-spec/hw-description/$(PLATFORM_NAME)_presynth.pdi ]; then \
-		echo "INFO: BOOT image genration started...";  \
+	@if [ -f project-spec/hw-description/$(PLATFORM_NAME).pdi ]; then \
+		echo "INFO: BOOT image generation started...";  \
 		petalinux-package --boot --u-boot --plm no --psmfw no --qemu-rootfs no --force;  \
     cp -rf images/linux/BOOT.BIN ${SW_COMP_DIR}/platform/;  \
 	else  \
-		echo "WARNING: "$(PLATFORM_NAME)_presynth.pdi" file not found. Skipping BOOT image generation.";  \
+		echo "WARNING: "$(PLATFORM_NAME).pdi" file not found. Skipping BOOT image generation.";  \
 	fi

--- a/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/Makefile
@@ -53,10 +53,10 @@ all: extract_pdi boot_common device-tree sw_comp
 
 bootimage:
 	$(info "BOOT image for platforms")
-	@if [ -f $(CWD)/$(PLATFORM_NAME)_presynth.pdi ]; then \
+	@if [ -f $(CWD)/$(PLATFORM_NAME).pdi ]; then \
 		echo "INFO: BOOT image genration started...";  \
 		$(BOOTGEN) -arch versal -image $(CWD)/bootgen.bif -o images/linux/BOOT.BIN -w;  \
     cp -rf images/linux/BOOT.BIN ${SW_COMP_DIR}/platform/;  \
 	else  \
-		echo "WARNING: "$(PLATFORM_NAME)_presynth.pdi" file not found. Skipping BOOT image generation.";  \
+		echo "WARNING: "$(PLATFORM_NAME).pdi" file not found. Skipping BOOT image generation.";  \
 	fi

--- a/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/bootgen.bif
+++ b/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/bootgen.bif
@@ -1,7 +1,7 @@
 the_ROM_image:
 {
 image {
-	{ type=bootimage, file=xilinx_vck190_base_202020_1_presynth.pdi }
+	{ type=bootimage, file=xilinx_vck190_base_202020_1.pdi }
 }
 image {
 	id = 0x1c000000, name=apu_subsystem 

--- a/Xilinx_Official_Platforms/xilinx_zc706_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zc706_base/Makefile
@@ -39,7 +39,7 @@ help::
 xsa:
 	$(MAKE) -C hw all
 
-linux: xsa
+linux: $(XSA)
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
@@ -52,7 +52,7 @@ platform:
 	@if [ -d $(SW_COMP_DIR)/platform/filesystem ]; then cp -rf ${SW_COMP_DIR}/platform/filesystem $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/sw/${PLATFORM_NAME}/xrt/; fi
 
 pre-built:
-	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
+	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir -p $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
 
 clean:
 	$(MAKE) -C hw clean

--- a/Xilinx_Official_Platforms/xilinx_zc706_base/sw/petalinux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zc706_base/sw/petalinux/Makefile
@@ -37,7 +37,7 @@ image_rootfs:
 	cp -f images/linux/rootfs.tar.gz ${SW_COMP_DIR}/platform/filesystem/rootfs.tar.gz
 	cp -f images/linux/rootfs.ext4 ${SW_COMP_DIR}/platform/filesystem/rootfs.ext4
 
-all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs bootimage
+all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs
 
 bootimage:
 	$(info "No BOOT image for non-PR platforms")

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base/Makefile
@@ -39,7 +39,7 @@ help::
 xsa:
 	$(MAKE) -C hw all
 
-linux: xsa
+linux: $(XSA)
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
@@ -52,7 +52,7 @@ platform:
 	@if [ -d $(SW_COMP_DIR)/platform/filesystem ]; then cp -rf ${SW_COMP_DIR}/platform/filesystem $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/sw/${PLATFORM_NAME}/xrt/; fi
 
 pre-built:
-	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
+	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir -p $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
 
 clean:
 	$(MAKE) -C hw clean

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base/sw/petalinux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base/sw/petalinux/Makefile
@@ -38,7 +38,7 @@ image_rootfs:
 	cp -f images/linux/rootfs.tar.gz ${SW_COMP_DIR}/platform/filesystem/rootfs.tar.gz
 	cp -f images/linux/rootfs.ext4 ${SW_COMP_DIR}/platform/filesystem/rootfs.ext4
 
-all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs bootimage
+all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs
 
 bootimage:
 	$(info "BOOT image for platforms")

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/Makefile
@@ -39,7 +39,7 @@ help::
 xsa:
 	$(MAKE) -C hw all
 
-linux: xsa
+linux: $(XSA)
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
@@ -52,7 +52,7 @@ platform:
 	@if [ -d $(SW_COMP_DIR)/platform/filesystem ]; then cp -rf ${SW_COMP_DIR}/platform/filesystem $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/sw/${PLATFORM_NAME}/xrt/; fi
 
 pre-built:
-	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
+	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir -p $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
 
 clean:
 	$(MAKE) -C hw clean

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/sw/petalinux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/sw/petalinux/Makefile
@@ -38,7 +38,7 @@ image_rootfs:
 	cp -f images/linux/rootfs.tar.gz ${SW_COMP_DIR}/platform/filesystem/rootfs.tar.gz
 	cp -f images/linux/rootfs.ext4 ${SW_COMP_DIR}/platform/filesystem/rootfs.ext4
 
-all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs bootimage
+all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs
 
 bootimage:
 	$(info "BOOT image for platforms")

--- a/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/sw/prebuilt_linux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu102_base_dfx/sw/prebuilt_linux/Makefile
@@ -52,7 +52,7 @@ sw_comp:
 	cp -f images/linux/zynqmp_fsbl.elf ${SW_COMP_DIR}/platform/boot/fsbl.elf
 	cp -f images/linux/system.dtb ${SW_COMP_DIR}/platform/image/system.dtb
 
-all: extract_bit boot_common device-tree sw_comp bootimage
+all: extract_bit boot_common device-tree sw_comp
 
 bootimage:
 	$(info "BOOT image for platforms")

--- a/Xilinx_Official_Platforms/xilinx_zcu104_base/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu104_base/Makefile
@@ -39,7 +39,7 @@ help::
 xsa:
 	$(MAKE) -C hw all
 
-linux: xsa
+linux: $(XSA)
 	$(MAKE) -C sw all
 
 petalinux_sysroot:
@@ -52,7 +52,7 @@ platform:
 	@if [ -d $(SW_COMP_DIR)/platform/filesystem ]; then cp -rf ${SW_COMP_DIR}/platform/filesystem $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/sw/${PLATFORM_NAME}/xrt/; fi
 
 pre-built:
-	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
+	@if [ -f $(SW_COMP_DIR)/platform/BOOT.BIN ]; then mkdir -p $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/ && cp -rf $(SW_COMP_DIR)/platform/BOOT.BIN $(OUTPUT_PATH)/${PLATFORM_NAME}/export/${PLATFORM_NAME}/pre-built/; fi
 
 clean:
 	$(MAKE) -C hw clean

--- a/Xilinx_Official_Platforms/xilinx_zcu104_base/sw/petalinux/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_zcu104_base/sw/petalinux/Makefile
@@ -38,7 +38,7 @@ image_rootfs:
 	cp -f images/linux/rootfs.tar.gz ${SW_COMP_DIR}/platform/filesystem/rootfs.tar.gz
 	cp -f images/linux/rootfs.ext4 ${SW_COMP_DIR}/platform/filesystem/rootfs.ext4
 
-all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs bootimage
+all: refresh_hw kernel_config rootfs_config linux sw_comp image_rootfs
 
 bootimage:
 	$(info "BOOT image for platforms")


### PR DESCRIPTION
Generate BOOT.BIN only from post-impl PDI, Don't generate it by default