### PR TITLE
2019.2: Makefile fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c   text
+*.h   text
+*.cpp text
+*.hpp text
+*.py  text
+*.xdc text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Documents
+*.doc  diff=astextplain
+*.DOC  diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF  diff=astextplain
+*.rtf  diff=astextplain
+*.RTF  diff=astextplain
+
+# Images
+*.bmp  binary
+*.epgz binary
+*.jpg  binary
+*.jpeg binary
+*.png  binary
+
+# Images - Large
+*.tif  filter=lfs diff=lfs merge=lfs -text
+*.tiff filter=lfs diff=lfs merge=lfs -text
+
+# Audio
+*.mp3  filter=lfs diff=lfs merge=lfs -text
+*.wav  filter=lfs diff=lfs merge=lfs -text
+
+# Video
+*.mov  filter=lfs diff=lfs merge=lfs -text
+*.mkv  filter=lfs diff=lfs merge=lfs -text
+*.mp4  filter=lfs diff=lfs merge=lfs -text
+*.mpeg filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,167 @@
+# .gitignore
+
+# archive files
+*.bz2
+*.gz
+*.zip
+*.tar
+
+# common
+*.log
+
+# c/c++
+# prerequisites
+*.d
+# compiled object files
+*.o
+*.obj
+*.bc
+*.elf
+*.ll
+*.lo
+*.ko
+*.slo
+# precompiled headers
+*.gch
+*.pch
+# compiled static libraries
+*.a
+*.la
+*.lai
+*.lib
+# compiled dynamic libraries
+*.so
+*.so.*
+*.dll
+*.dylib
+# linker output
+*.ilk
+*.map
+*.exp
+# executables
+*.exe
+*.out
+*.app
+# debug files
+*.dSYM/
+*.idb
+*.pdb
+*.su
+
+# cmake
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+cmake-build-debug/
+cmake-build-release/
+
+# cuda
+*.i
+*.ii
+*.gpu
+*.ptx
+*.cubin
+*.fatbin
+
+# eclipse
+.metadata/
+
+# git
+patch/
+
+# jetbrains ide
+*.iml
+.idea/
+
+# jupyter notebook
+.ipynb_checkpoints/
+
+# python byte-compiled, optimized files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# latex
+## core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+## intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+## bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+## build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+## build tool directories for auxiliary files
+latex.out/
+
+# xilinx
+# generated folders
+*.cache
+*.gen
+*.hw
+*.ip_user_files
+*.runs
+*.sdk
+*.srcs
+.Xil
+# generated files
+*_sys.txt
+*.jou
+*.xpr
+
+# media
+video/
+
+# folders
+archive/
+backup/
+!bin
+bin/*
+build/
+build_isolated/
+checkpoint/
+devel/
+devel_isolated/
+inbox/
+logs/
+model/
+outbox/
+output/
+results/
+training_results/
+Temp/
+
+# inclusions
+!bin/setup.sh
+!bin/.aliases.sh
+
+# Operating system files
+~*.*
+.DS_Store
+Thumbs.db

--- a/Xilinx_Official_Platforms/zc702_base/Makefile
+++ b/Xilinx_Official_Platforms/zc702_base/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a9
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zc706_base/Makefile
+++ b/Xilinx_Official_Platforms/zc706_base/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a9
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu102_base/Makefile
+++ b/Xilinx_Official_Platforms/zcu102_base/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a53
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu102_base_dfx/Makefile
+++ b/Xilinx_Official_Platforms/zcu102_base_dfx/Makefile
@@ -5,7 +5,6 @@ XSCT = $(XILINX_VITIS)/bin/xsct
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu102_dpu/Makefile
+++ b/Xilinx_Official_Platforms/zcu102_dpu/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a53
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu104_base/Makefile
+++ b/Xilinx_Official_Platforms/zcu104_base/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a53
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu104_dpu/Makefile
+++ b/Xilinx_Official_Platforms/zcu104_dpu/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a53
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu104_smart_camera/Makefile
+++ b/Xilinx_Official_Platforms/zcu104_smart_camera/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a53
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu104_ss/Makefile
+++ b/Xilinx_Official_Platforms/zcu104_ss/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a53
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm

--- a/Xilinx_Official_Platforms/zcu104_vcu_ml/Makefile
+++ b/Xilinx_Official_Platforms/zcu104_vcu_ml/Makefile
@@ -6,7 +6,6 @@ CPU_ARCH=a53
 
 .phony: all
 
-$(PLATOFORM): all
 all: $(PLATFORM)
 
 $(PLATFORM): xsa petalinux_proj pfm


### PR DESCRIPTION
This pull request contains fixes that
- Add .gitignore and .gitattributes files to the project repository
- Fixes Makefiles by removing an un-used and mis-spelt target `$(PLATOFORM): all`