### PR TITLE
Fixed bug in dtb_gen Makefile

### DIFF
--- a/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/dtb_gen/Makefile
+++ b/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/dtb_gen/Makefile
@@ -9,7 +9,6 @@ SHELL := /bin/bash
 VER_MAIN ?= 2024
 VER_MIN ?= 2
 VERSION1 ?= $(VER_MAIN).$(VER_MIN)
-TOOLS ?= /proj/xbuilds/$(VERSION1)_daily_latest/installs/lin64/Vitis/$(VERSION1)/
 XSA ?= ../../../hw/build/hw.xsa
 SDT_OUT ?= sdt_out
 USER_DTSI ?= ../user_dts/system-user.dtsi 
@@ -26,7 +25,7 @@ get_sources:
 gen_sdt:
 	$(RM) -rf $(SDT_OUT)
 	$(info "DTB generation started using stdgen+lopper")
-	$(TOOLS)/bin/xsct -eval "sdtgen set_dt_param -dir $(SDT_OUT) -xsa $(XSA) -board_dts versal-vck190-rev1.1 -zocl enable -include_dts $(USER_DTSI); sdtgen generate_sdt"
+	$(XSCT) -eval "sdtgen set_dt_param -dir $(SDT_OUT) -xsa $(XSA) -board_dts versal-vck190-rev1.1 -zocl enable -include_dts $(USER_DTSI); sdtgen generate_sdt"
  
 gen_dtb:
 	$(RM) -rf system.dtb

--- a/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/dtb_gen/lopper_settings.sh
+++ b/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/dtb_gen/lopper_settings.sh
@@ -3,7 +3,6 @@
 # Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #******************************************************************************
-export XILINX_VITIS=/proj/xbuilds/2024.2_daily_latest/installs/lin64/Vitis/2024.2
 
 export PYTHON_VER="python-3.8.3"
 export CMAKE_VER="cmake-3.24.2"


### PR DESCRIPTION
# Issue 

CWD: Vitis_Embedded_Platform_Source/Xilinx_Official_Platforms/xilinx_vck190_base
Command ` make all PREBUILT_LINUX_PATH=/some/path/to/vitis/xilinx-versal-common-v2024.2`

Error:

```sscs
make[3]: Entering directory 'Vitis_Embedded_Platform_Source/Xilinx_Official_Platforms/xilinx_vck190_base/sw/prebuilt_linux/dtb_gen'
if [ ! -d "./lopper" ];then \
	git clone https://github.com/devicetree-org/lopper; \
	cd lopper && git checkout v0.2024.x; \
fi
Cloning into 'lopper'...
remote: Enumerating objects: 6721, done.
remote: Counting objects: 100% (1665/1665), done.
remote: Compressing objects: 100% (538/538), done.
remote: Total 6721 (delta 1235), reused 1159 (delta 1127), pack-reused 5056 (from 2)
Receiving objects: 100% (6721/6721), 5.74 MiB | 20.27 MiB/s, done.
Resolving deltas: 100% (4932/4932), done.
branch 'v0.2024.x' set up to track 'origin/v0.2024.x'.
Switched to a new branch 'v0.2024.x'
"DTB generation started using stdgen+lopper"
rm -f -rf sdt_out
/proj/xbuilds/2024.2_daily_latest/installs/lin64/Vitis/2024.2/bin/xsct -eval "sdtgen set_dt_param -dir sdt_out -xsa Vitis_Embedded_Platform_Source/Xilinx_Official_Platforms/xilinx_vck190_base/hw/build/hw.xsa -board_dts versal-vck190-rev1.1 -zocl enable -include_dts ../user_dts/system-user.dtsi ; sdtgen generate_sdt"
/bin/bash: line 1: /proj/xbuilds/2024.2_daily_latest/installs/lin64/Vitis/2024.2/bin/xsct: No such file or directory
make[3]: *** [Makefile:29: gen_sdt] Error 127
```

To replicate, you can go to the fork and checkout to `HEAD~1` and run the command. Seems like the Makefile inside the `dtb_gen` directory is not configured correctly. I changed the `$(TOOLS)/usr/bin/xsct` command to `$(XSCT)`.  

Edit:
I thought 'lopper_settings.sh' was unused, but it turns out it is actually used by lopper once the repo is cloned. However, I had to remove the `XILINX_VITIS` export command. The user should already export this because the makefile assumes the user ran `settings64.sh` beforehand.